### PR TITLE
MTDSA-23395: Individuals-State-Benefit-IF-Migration

### DIFF
--- a/app/api/support/DownstreamResponseMappingSupport.scala
+++ b/app/api/support/DownstreamResponseMappingSupport.scala
@@ -28,14 +28,15 @@ trait DownstreamResponseMappingSupport {
       implicit logContext: EndpointLogContext): ErrorWrapper = {
 
     lazy val defaultErrorCodeMapping: String => MtdError = {
-      case "UNMATCHED_STUB_ERROR" => {
+      case "UNMATCHED_STUB_ERROR" =>
         logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No matching stub was found")
         RuleIncorrectGovTestScenarioError
-      }
-      case code => {
+      case "INVALID_CORRELATION_ID" | "INVALID_CORRELATIONID" =>
+        logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - An internal server error occurred")
+        InternalError
+      case code =>
         logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
         InternalError
-      }
     }
 
     downstreamResponseWrapper match {

--- a/app/config/FeatureSwitches.scala
+++ b/app/config/FeatureSwitches.scala
@@ -18,7 +18,15 @@ package config
 
 import play.api.Configuration
 
-case class FeatureSwitches(featureSwitchConfig: Configuration)
+case class FeatureSwitches(featureSwitchConfig: Configuration){
+
+  val isDesIf_MigrationEnabled: Boolean                = isEnabled("desIf_Migration")
+
+  def isEnabled(feature: String): Boolean              = isConfigTrue(feature + ".enabled")
+  def isReleasedInProduction(feature: String): Boolean = isConfigTrue(feature + ".released-in-production")
+
+  private def isConfigTrue(feature: String): Boolean = featureSwitchConfig.getOptional[Boolean](feature).getOrElse(true)
+}
 
 object FeatureSwitches {
   def apply()(implicit appConfig: AppConfig): FeatureSwitches = FeatureSwitches(appConfig.featureSwitches)

--- a/app/v1/services/AmendBenefitAmountsService.scala
+++ b/app/v1/services/AmendBenefitAmountsService.scala
@@ -42,7 +42,6 @@ class AmendBenefitAmountsService @Inject() (connector: AmendBenefitAmountsConnec
       "INVALID_TAXABLE_ENTITY_ID"       -> NinoFormatError,
       "INVALID_TAX_YEAR"                -> TaxYearFormatError,
       "INVALID_BENEFIT_ID"              -> BenefitIdFormatError,
-      "INVALID_CORRELATIONID"           -> InternalError,
       "INVALID_PAYLOAD"                 -> InternalError,
       "INVALID_REQUEST_BEFORE_TAX_YEAR" -> RuleTaxYearNotEndedError,
       "SERVER_ERROR"                    -> InternalError,
@@ -50,7 +49,6 @@ class AmendBenefitAmountsService @Inject() (connector: AmendBenefitAmountsConnec
     )
 
     val extraTysErrors = Map(
-      "INVALID_CORRELATION_ID" -> InternalError,
       "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
     )
 

--- a/app/v1/services/AmendBenefitService.scala
+++ b/app/v1/services/AmendBenefitService.scala
@@ -38,7 +38,6 @@ class AmendBenefitService @Inject() (connector: AmendBenefitConnector) extends B
     "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
     "INVALID_TAX_YEAR"          -> TaxYearFormatError,
     "INVALID_BENEFIT_ID"        -> BenefitIdFormatError,
-    "INVALID_CORRELATIONID"     -> InternalError,
     "INVALID_PAYLOAD"           -> InternalError,
     "UPDATE_FORBIDDEN"          -> RuleUpdateForbiddenError,
     "NO_DATA_FOUND"             -> NotFoundError,

--- a/app/v1/services/CreateBenefitService.scala
+++ b/app/v1/services/CreateBenefitService.scala
@@ -39,7 +39,6 @@ class CreateBenefitService @Inject() (connector: CreateBenefitConnector) extends
   private val downstreamErrorMap: Map[String, MtdError] = Map(
     "INVALID_TAXABLE_ENTITY_ID"   -> NinoFormatError,
     "INVALID_TAX_YEAR"            -> TaxYearFormatError,
-    "INVALID_CORRELATIONID"       -> InternalError,
     "INVALID_PAYLOAD"             -> InternalError,
     "BENEFIT_TYPE_ALREADY_EXISTS" -> RuleBenefitTypeExists,
     "NOT_SUPPORTED_TAX_YEAR"      -> RuleTaxYearNotEndedError,

--- a/app/v1/services/DeleteBenefitAmountsService.scala
+++ b/app/v1/services/DeleteBenefitAmountsService.scala
@@ -41,6 +41,7 @@ class DeleteBenefitAmountsService @Inject() (connector: DeleteBenefitAmountsConn
       "INVALID_TAX_YEAR"          -> TaxYearFormatError,
       "INVALID_BENEFIT_ID"        -> BenefitIdFormatError,
       "INVALID_CORRELATIONID"     -> InternalError,
+      "INVALID_CORRELATION_ID"    -> InternalError,
       "NO_DATA_FOUND"             -> NotFoundError,
       "SERVER_ERROR"              -> InternalError,
       "SERVICE_UNAVAILABLE"       -> InternalError

--- a/app/v1/services/DeleteBenefitAmountsService.scala
+++ b/app/v1/services/DeleteBenefitAmountsService.scala
@@ -40,8 +40,6 @@ class DeleteBenefitAmountsService @Inject() (connector: DeleteBenefitAmountsConn
       "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
       "INVALID_TAX_YEAR"          -> TaxYearFormatError,
       "INVALID_BENEFIT_ID"        -> BenefitIdFormatError,
-      "INVALID_CORRELATIONID"     -> InternalError,
-      "INVALID_CORRELATION_ID"    -> InternalError,
       "NO_DATA_FOUND"             -> NotFoundError,
       "SERVER_ERROR"              -> InternalError,
       "SERVICE_UNAVAILABLE"       -> InternalError

--- a/app/v1/services/DeleteBenefitService.scala
+++ b/app/v1/services/DeleteBenefitService.scala
@@ -39,7 +39,6 @@ class DeleteBenefitService @Inject() (connector: DeleteBenefitConnector) extends
     "INVALID_TAX_YEAR"          -> TaxYearFormatError,
     "INVALID_BENEFIT_ID"        -> BenefitIdFormatError,
     "DELETE_FORBIDDEN"          -> RuleDeleteForbiddenError,
-    "INVALID_CORRELATIONID"     -> InternalError,
     "NO_DATA_FOUND"             -> NotFoundError,
     "SERVER_ERROR"              -> InternalError,
     "SERVICE_UNAVAILABLE"       -> InternalError

--- a/app/v1/services/IgnoreBenefitService.scala
+++ b/app/v1/services/IgnoreBenefitService.scala
@@ -38,7 +38,6 @@ class IgnoreBenefitService @Inject() (connector: IgnoreBenefitConnector) extends
     ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
     ("INVALID_TAX_YEAR", TaxYearFormatError),
     ("INVALID_BENEFIT_ID", BenefitIdFormatError),
-    ("INVALID_CORRELATION_ID", InternalError),
     ("IGNORE_FORBIDDEN", RuleIgnoreForbiddenError),
     ("NO_DATA_FOUND", NotFoundError),
     ("NOT_SUPPORTED_TAX_YEAR", RuleTaxYearNotEndedError),

--- a/app/v1/services/ListBenefitsService.scala
+++ b/app/v1/services/ListBenefitsService.scala
@@ -44,7 +44,6 @@ class ListBenefitsService @Inject() (connector: ListBenefitsConnector) extends B
       "INVALID_TAX_YEAR"          -> TaxYearFormatError,
       "INVALID_BENEFIT_ID"        -> BenefitIdFormatError,
       "INVALID_VIEW"              -> InternalError,
-      "INVALID_CORRELATIONID"     -> InternalError,
       "NO_DATA_FOUND"             -> NotFoundError,
       "TAX_YEAR_NOT_SUPPORTED"    -> RuleTaxYearNotSupportedError,
       "SERVER_ERROR"              -> InternalError,

--- a/app/v1/services/ListBenefitsService.scala
+++ b/app/v1/services/ListBenefitsService.scala
@@ -51,7 +51,6 @@ class ListBenefitsService @Inject() (connector: ListBenefitsConnector) extends B
     )
 
     val extraTysErrors: Map[String, MtdError] = Map(
-      "INVALID_CORRELATION_ID" -> InternalError,
       "NOT_FOUND"              -> NotFoundError
     )
 

--- a/app/v1/services/UnignoreBenefitService.scala
+++ b/app/v1/services/UnignoreBenefitService.scala
@@ -38,7 +38,6 @@ class UnignoreBenefitService @Inject() (connector: UnignoreBenefitConnector) ext
   private val downstreamErrorMap: Map[String, MtdError] = Map(
     ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
     ("INVALID_TAX_YEAR", TaxYearFormatError),
-    ("INVALID_CORRELATION_ID", InternalError),
     ("INVALID_BENEFIT_ID", BenefitIdFormatError),
     ("CUSTOMER_ADDED", RuleUnignoreForbiddenError),
     ("NO_DATA_FOUND", NotFoundError),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,13 +93,6 @@ api {
   gateway.context = "individuals/state-benefits"
 }
 
-feature-switch {
-  desIf_Migration {
-    enabled = true
-    released-in-production = false
-  }
-}
-
 bootstrap.http.headersAllowlist = [ "Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id" ]
 
 internalServiceHostPatterns = [ "localhost" ]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,6 +93,13 @@ api {
   gateway.context = "individuals/state-benefits"
 }
 
+feature-switch {
+  desIf_Migration {
+    enabled = true
+    released-in-production = false
+  }
+}
+
 bootstrap.http.headersAllowlist = [ "Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id" ]
 
 internalServiceHostPatterns = [ "localhost" ]

--- a/it/v1/endpoints/DeleteBenefitAmountsControllerISpec.scala
+++ b/it/v1/endpoints/DeleteBenefitAmountsControllerISpec.scala
@@ -166,6 +166,7 @@ class DeleteBenefitAmountsControllerISpec extends IntegrationBaseSpec {
           (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
           (BAD_REQUEST, "INVALID_BENEFIT_ID", BAD_REQUEST, BenefitIdFormatError),
           (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
           (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
           (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
           (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,8 +18,8 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.20.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.4.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.21.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 

--- a/test/api/connectors/ConnectorSpec.scala
+++ b/test/api/connectors/ConnectorSpec.scala
@@ -19,6 +19,7 @@ package api.connectors
 import api.mocks.MockHttpClient
 import mocks.MockAppConfig
 import org.scalamock.handlers.CallHandler
+import play.api.Configuration
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import support.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -115,6 +116,10 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     "Gov-Test-Scenario" -> "DEFAULT"
   )
 
+  val desIfMigrationEnabledConfig: Configuration = Configuration("desIf_Migration.enabled" -> true)
+
+  val desIfMigrationDisabledConfig: Configuration = Configuration("desIf_Migration.enabled" -> false)
+
   protected trait ConnectorTest extends MockHttpClient with MockAppConfig {
     protected val baseUrl: String = "http://test-BaseUrl"
 
@@ -175,6 +180,7 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     MockedAppConfig.desToken returns "des-token"
     MockedAppConfig.desEnvironment returns "des-environment"
     MockedAppConfig.desEnvironmentHeaders returns Some(allowedDesHeaders)
+    MockedAppConfig.featureSwitches returns desIfMigrationDisabledConfig
 
   }
 
@@ -186,7 +192,7 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     MockedAppConfig.ifsToken returns "ifs-token"
     MockedAppConfig.ifsEnvironment returns "ifs-environment"
     MockedAppConfig.ifsEnvironmentHeaders returns Some(allowedIfsHeaders)
-
+    MockedAppConfig.featureSwitches returns desIfMigrationEnabledConfig
   }
 
   protected trait Api1651Test extends ConnectorTest {

--- a/test/api/connectors/ConnectorSpec.scala
+++ b/test/api/connectors/ConnectorSpec.scala
@@ -19,7 +19,6 @@ package api.connectors
 import api.mocks.MockHttpClient
 import mocks.MockAppConfig
 import org.scalamock.handlers.CallHandler
-import play.api.Configuration
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import support.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
@@ -116,10 +115,6 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     "Gov-Test-Scenario" -> "DEFAULT"
   )
 
-  val desIfMigrationEnabledConfig: Configuration = Configuration("desIf_Migration.enabled" -> true)
-
-  val desIfMigrationDisabledConfig: Configuration = Configuration("desIf_Migration.enabled" -> false)
-
   protected trait ConnectorTest extends MockHttpClient with MockAppConfig {
     protected val baseUrl: String = "http://test-BaseUrl"
 
@@ -180,7 +175,6 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     MockedAppConfig.desToken returns "des-token"
     MockedAppConfig.desEnvironment returns "des-environment"
     MockedAppConfig.desEnvironmentHeaders returns Some(allowedDesHeaders)
-    MockedAppConfig.featureSwitches returns desIfMigrationDisabledConfig
 
   }
 
@@ -192,7 +186,6 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     MockedAppConfig.ifsToken returns "ifs-token"
     MockedAppConfig.ifsEnvironment returns "ifs-environment"
     MockedAppConfig.ifsEnvironmentHeaders returns Some(allowedIfsHeaders)
-    MockedAppConfig.featureSwitches returns desIfMigrationEnabledConfig
   }
 
   protected trait Api1651Test extends ConnectorTest {

--- a/test/config/FeatureSwitchesSpec.scala
+++ b/test/config/FeatureSwitchesSpec.scala
@@ -21,21 +21,29 @@ import support.UnitSpec
 
 class FeatureSwitchesSpec extends UnitSpec {
 
-  private val configuration = Configuration(
-    "feature-switch.enabled" -> true
-  )
-
-  private val featureSwitches = FeatureSwitches(configuration)
-
   "FeatureSwitches" should {
-    "return true" when {
-      "the feature switch is set to true" in {
-        featureSwitches.featureSwitchConfig.getOptional[Boolean]("feature-switch.enabled") shouldBe Some(true)
+    "be true" when {
+      "absent from the config" in {
+        val configuration = Configuration.empty
+        val featureSwitches = FeatureSwitches(configuration)
+
+        featureSwitches.isDesIf_MigrationEnabled shouldBe true
+      }
+
+      "enabled" in {
+        val configuration = Configuration("desIf_Migration.enabled" -> true)
+        val featureSwitches = FeatureSwitches(configuration)
+
+        featureSwitches.isDesIf_MigrationEnabled shouldBe true
       }
     }
-    "return false" when {
-      "the feature switch is not present in the config" in {
-        featureSwitches.featureSwitchConfig.getOptional[Boolean]("invalid") shouldBe None
+
+    "be false" when {
+      "disabled" in {
+        val configuration = Configuration("desIf_Migration.enabled" -> false)
+        val featureSwitches = FeatureSwitches(configuration)
+
+        featureSwitches.isDesIf_MigrationEnabled shouldBe false
       }
     }
   }

--- a/test/config/FeatureSwitchesSpec.scala
+++ b/test/config/FeatureSwitchesSpec.scala
@@ -27,25 +27,24 @@ class FeatureSwitchesSpec extends UnitSpec {
         val configuration = Configuration.empty
         val featureSwitches = FeatureSwitches(configuration)
 
-        featureSwitches.isDesIf_MigrationEnabled shouldBe true
+        featureSwitches.isEnabled("some-feature") shouldBe true
       }
 
       "enabled" in {
-        val configuration = Configuration("desIf_Migration.enabled" -> true)
+        val configuration = Configuration("some-feature.enabled" -> true)
         val featureSwitches = FeatureSwitches(configuration)
 
-        featureSwitches.isDesIf_MigrationEnabled shouldBe true
+        featureSwitches.isEnabled("some-feature") shouldBe true
       }
     }
 
     "be false" when {
       "disabled" in {
-        val configuration = Configuration("desIf_Migration.enabled" -> false)
+        val configuration = Configuration("some-feature" -> false)
         val featureSwitches = FeatureSwitches(configuration)
 
-        featureSwitches.isDesIf_MigrationEnabled shouldBe false
+        featureSwitches.isEnabled("some-feature") shouldBe false
       }
     }
   }
-
 }

--- a/test/config/FeatureSwitchesSpec.scala
+++ b/test/config/FeatureSwitchesSpec.scala
@@ -40,7 +40,7 @@ class FeatureSwitchesSpec extends UnitSpec {
 
     "be false" when {
       "disabled" in {
-        val configuration = Configuration("some-feature" -> false)
+        val configuration = Configuration("some-feature.enabled" -> false)
         val featureSwitches = FeatureSwitches(configuration)
 
         featureSwitches.isEnabled("some-feature") shouldBe false

--- a/test/v1/connectors/DeleteBenefitAmountsConnectorSpec.scala
+++ b/test/v1/connectors/DeleteBenefitAmountsConnectorSpec.scala
@@ -19,6 +19,7 @@ package v1.connectors
 import api.connectors.{ConnectorSpec, DownstreamOutcome}
 import api.models.domain.{Nino, TaxYear}
 import api.models.outcomes.ResponseWrapper
+import play.api.Configuration
 import v1.models.domain.BenefitId
 import v1.models.request.deleteBenefitAmounts.DeleteBenefitAmountsRequestData
 
@@ -35,6 +36,8 @@ class DeleteBenefitAmountsConnectorSpec extends ConnectorSpec {
         def taxYear: TaxYear                               = TaxYear.fromMtd("2017-18")
         val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
+        MockedAppConfig.featureSwitches returns Configuration("desIf_Migration.enabled" -> false)
+
         willDelete(s"$baseUrl/income-tax/income/state-benefits/$nino/${request.taxYear.asMtd}/${request.benefitId}") returns Future.successful(
           outcome)
 
@@ -46,6 +49,8 @@ class DeleteBenefitAmountsConnectorSpec extends ConnectorSpec {
       "the downstream call is successful, not tax year specific and the desIf_Migration feature-switch is turned on" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2017-18")
         val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+
+        MockedAppConfig.featureSwitches returns Configuration("desIf_Migration.enabled" -> true)
 
         willDelete(s"$baseUrl/income-tax/income/state-benefits/$nino/${request.taxYear.asMtd}/${request.benefitId}") returns Future.successful(
           outcome)

--- a/test/v1/connectors/DeleteBenefitAmountsConnectorSpec.scala
+++ b/test/v1/connectors/DeleteBenefitAmountsConnectorSpec.scala
@@ -31,8 +31,20 @@ class DeleteBenefitAmountsConnectorSpec extends ConnectorSpec {
 
   "DeleteBenefitAmountsConnector" should {
     "return a 200 result on delete" when {
-      "the downstream call is successful and not tax year specific" in new DesTest with Test {
+      "the downstream call is successful, not tax year specific and the desIf_Migration feature-switch is turned off" in new DesTest with Test {
         def taxYear: TaxYear                               = TaxYear.fromMtd("2017-18")
+        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+
+        willDelete(s"$baseUrl/income-tax/income/state-benefits/$nino/${request.taxYear.asMtd}/${request.benefitId}") returns Future.successful(
+          outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.deleteBenefitAmounts(request))
+
+        result shouldBe outcome
+      }
+
+      "the downstream call is successful, not tax year specific and the desIf_Migration feature-switch is turned on" in new IfsTest with Test {
+        def taxYear: TaxYear = TaxYear.fromMtd("2017-18")
         val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(s"$baseUrl/income-tax/income/state-benefits/$nino/${request.taxYear.asMtd}/${request.benefitId}") returns Future.successful(

--- a/test/v1/services/DeleteBenefitAmountsServiceSpec.scala
+++ b/test/v1/services/DeleteBenefitAmountsServiceSpec.scala
@@ -61,6 +61,7 @@ class DeleteBenefitAmountsServiceSpec extends ServiceSpec {
           "INVALID_TAX_YEAR"          -> TaxYearFormatError,
           "INVALID_BENEFIT_ID"        -> BenefitIdFormatError,
           "INVALID_CORRELATIONID"     -> InternalError,
+          "INVALID_CORRELATION_ID"    -> InternalError,
           "NO_DATA_FOUND"             -> NotFoundError,
           "SERVER_ERROR"              -> InternalError,
           "SERVICE_UNAVAILABLE"       -> InternalError


### PR DESCRIPTION
- Adds first feature switch clause, and desIf_Migration feature-switch, to application.conf
- Adds feature switch if-else clause to DeleteBenefitAmountsConnector
- Adds respective tests to unit spec
- Adds INVALID_CORRELATION_ID error code to downstreamErrorMap and its spec
- Adds case for INVALID_CORRELATION_ID and alternate case to DownstreamResponseMappingSupport
- Adds necessary FeatureSwitches values and defs
- Modifies tests in FeatureSwitchesSpec to account for the first feature switch implementation